### PR TITLE
Sanitize depends-on on make-project to be a list

### DIFF
--- a/quickproject.lisp
+++ b/quickproject.lisp
@@ -152,6 +152,7 @@ marker is the string \"\(#|\" and the template end marker is the string
                      ((:include-copyright *include-copyright*) *include-copyright*))
   "Create a project skeleton for NAME in PATHNAME. If DEPENDS-ON is provided,
 it is used as the asdf defsystem depends-on list."
+  (check-type depends-on list)
   (when (pathname-name pathname)
     (warn "Coercing ~S to directory"
           pathname)

--- a/quickproject.lisp
+++ b/quickproject.lisp
@@ -65,7 +65,7 @@ not already exist."
   (terpri stream))
 
 (defun write-system-file (name file &key depends-on)
-  (with-new-file (stream file)
+  (with-new-file (stream (string-downcase file))
     (file-comment-header stream)
     (write-system-form name
                        :depends-on depends-on
@@ -85,7 +85,7 @@ not already exist."
     (format stream "  (:use #:cl))~%~%")))
 
 (defun write-application-file (name file)
-  (with-new-file (stream file)
+  (with-new-file (stream (string-downcase file))
     (file-comment-header stream)
     (format stream "(in-package ~S)~%~%" (uninterned-symbolize name))
     (format stream ";;; ~S goes here. Hacks and glory await!~%~%" name)))


### PR DESCRIPTION
This prevents creating project directory, when make-project is going to
fail due to non-list depends-on. Fixes #4.
