### PR TITLE
rename depends-on

### DIFF
--- a/quickproject.lisp
+++ b/quickproject.lisp
@@ -140,6 +140,6 @@ it is used as the asdf defsystem depends-on list."
       (pushnew *default-pathname-defaults* asdf:*central-registry*
                :test 'equal)
       (dolist (hook *after-make-project-hooks*)
-        (funcall hook pathname :depends-on depends-on :name name
+        (funcall hook pathname :depends-on *depends-on* :name name
                  :allow-other-keys t)))
     name))


### PR DESCRIPTION
fixes this error:

quickproject.lisp:143:9:
  warning: 
    undefined variable: QUICKPROJECT::DEPENDS-ON
    ==>
      (SB-C::%FUNCALL (SB-KERNEL:%COERCE-CALLABLE-FOR-CALL QUICKPROJECT::HOOK)
                      PATHNAME :DEPENDS-ON QUICKPROJECT::DEPENDS-ON :NAME
                      QUICKPROJECT::NAME :ALLOW-OTHER-KEYS T)
    

Compilation failed.
