### PR TITLE
change template-pathname->output-name to reliably match pathnames on ccl + linux

### DIFF
--- a/quickproject.lisp
+++ b/quickproject.lisp
@@ -52,9 +52,16 @@ MAKE-PROJECT, except that NAME is canonicalized if
 necessary. *DEFAULT-PATHNAME-DEFAULTS* bound to the newly created
 project directory.")
 
+(defun template-name-match-p (path template)
+  #+ccl
+  (and (string-equal (pathname-name path) (pathname-name template))
+       (string-equal (pathname-type path) (pathname-type template)))
+  #-ccl
+  (pathname-match-p path template))
+
 (defun template-pathname->output-name (path)
-  (if (or (pathname-match-p path "system.asd")
-          (pathname-match-p path "application.lisp"))
+  (if (or (template-name-match-p path "system.asd")
+          (template-name-match-p path "application.lisp"))
       (make-pathname :name *name* :defaults path)
     path))
 


### PR DESCRIPTION
fro me, running make-project using ccl64 1.11.5 on linux, the template files do not get renamed to match the project name

the problem seems to be that`(pathname-match-p "/some/expanded/template.name" "template.name")` is not true in this system

I always get confused about pathnames, so I have added a small function that drops this down to a string compare between file name and file type, which is probably a grotty way to do it, but fixes my problem