### PR TITLE
Add .gitignore to template

### DIFF
--- a/default-template/.gitignore
+++ b/default-template/.gitignore
@@ -1,0 +1,30 @@
+# Compiled code
+*.fas
+*.FASL
+*.fasl
+*.lisp-temp
+*.dfsl
+*.pfsl
+*.d64fsl
+*.p64fsl
+*.lx64fsl
+*.lx32fsl
+*.dx64fsl
+*.dx32fsl
+*.fx64fsl
+*.fx32fsl
+*.sx64fsl
+*.sx32fsl
+*.wx64fsl
+*.wx32fsl
+
+# Text editor garbage
+*~
+.#*
+\#*\#
+
+# Tag program
+GPATH
+GRTAGS
+GTAGS
+TAGS


### PR DESCRIPTION
I suggest adding this basic lisp/emacs `.gitignore` to the template.

I don't think it is very controversial, but it could be made into an optional addition as a configuration variable.