### PR TITLE
Add restarts for existing files in target directory

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -253,6 +253,19 @@ The latest version is 1.4.1, released on December 26th, 2019.
   </blockquote>
 </div>
 
+<div class='item'>
+    <div class='type'><a name='target-exists'>[condition]</a></div>
+    <div class='signature'>
+        <code class='name'>target-exists</code>
+    </div>
+
+    <blockquote class='description'>
+        <p>When the target directory exists, this error condition is signaled. If it isn't handled, the <tt>overwrite-everything</tt> restart
+        will be available in the debugger.
+    </blockquote>
+</div>
+
+
 
 <a name='feedback'><h2>Feedback</h2></a>
 

--- a/package.lisp
+++ b/package.lisp
@@ -10,14 +10,17 @@
            #:*template-directory*
            #:*include-copyright*
            #:default-template-parameters
-           #:*template-parameter-functions*)
+           #:*template-parameter-functions*
+           #:target-exists)
   (:shadowing-import-from #:html-template
                           #:fill-and-print-template
                           #:*template-start-marker*
                           #:*template-end-marker*)
   (:shadowing-import-from #:cl-fad
                           #:pathname-as-directory
-                          #:walk-directory))
+                          #:walk-directory
+                          #:file-exists-p
+                          #:delete-directory-and-files))
 
 (in-package #:quickproject)
 

--- a/quickproject.lisp
+++ b/quickproject.lisp
@@ -78,7 +78,7 @@ marker is the string \"\(#|\" and the template end marker is the string
                     (if-exists if-exists))
                (ensure-directories-exist target-pathname)
                (when (and (null if-exists)
-                          (fad:file-exists-p target-pathname))
+                          (file-exists-p target-pathname))
                  (error 'target-exists
                         :template-directory template-directory
                         :target-directory target-directory
@@ -154,7 +154,7 @@ it is used as the asdf defsystem depends-on list."
                         (error condition)))
         (overwrite-everything ()
           :report "Overwrite everything."
-          (cl-fad:delete-directory-and-files (target-directory c))
+          (delete-directory-and-files (target-directory c))
           (ensure-directories-exist (target-directory c))
           (rewrite-templates (template-directory c)
                              (target-directory c)


### PR DESCRIPTION
This demonstrates a potential solution to #18 using restarts. I think this is a good way to go about it, rather than silently destroying the old directory tree. A program calling `make-project` could `handle` the `target-exists` condition.