### PR TITLE
Add minimal template alternative

### DIFF
--- a/minimal-template/README.md
+++ b/minimal-template/README.md
@@ -1,0 +1,10 @@
+# (#| TMPL_VAR name |#)
+
+## License
+
+(#| TMPL_VAR license |#)
+
+### _(#| TMPL_VAR author |#)_(#| TMPL_IF copyright |#)
+
+(#| TMPL_VAR copyright |#)
+(#| /TMPL_IF |#)

--- a/minimal-template/application.lisp
+++ b/minimal-template/application.lisp
@@ -1,0 +1,6 @@
+(#| TMPL_IF copyright |#)
+;;;; (#| TMPL_VAR name |#).lisp
+;;
+;;;; (#| TMPL_VAR copyright |#)
+
+(#| /TMPL_IF |#)(in-package :(#| TMPL_VAR name |#))

--- a/minimal-template/package.lisp
+++ b/minimal-template/package.lisp
@@ -1,0 +1,7 @@
+(#| TMPL_IF copyright |#)
+;;;; package.lisp
+;;
+;;;; (#| TMPL_VAR copyright |#)
+
+(#| /TMPL_IF |#)(defpackage :(#| TMPL_VAR name |#)
+  (:use #:cl))

--- a/minimal-template/system.asd
+++ b/minimal-template/system.asd
@@ -1,0 +1,13 @@
+(#| TMPL_IF copyright |#);;;; (#| TMPL_VAR name |#).asd
+;;
+;;;; (#| TMPL_VAR copyright |#)
+
+(#| /TMPL_IF |#)(asdf:defsystem :(#| TMPL_VAR name |#)
+  :description "Describe (#| TMPL_VAR name |#) here"
+  :author "(#| TMPL_VAR author |#)"
+  :license  "(#| TMPL_VAR license |#)"
+  :version "0.0.1"
+  :serial t(#| TMPL_IF depends-on |#)
+  :depends-on (#| TMPL_VAR dependencies-string |#)(#| /TMPL_IF |#)
+  :components ((:file "package")
+               (:file "(#| TMPL_VAR name |#)")))


### PR DESCRIPTION
- No header comments or newlines, unless the copyright is shown.
- Use keywords :package rather than #:package.
- Put author at the bottom of the README.md.
- Remove extra boilerplate "describe here"

If this gets pulled in then I can archive https://github.com/equwal/minimalist-template