### PR TITLE
Update README.txt to markdown README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Quickproject creates the skeleton of a Common Lisp project.
 
-For full documentation, see doc/index.html.
+[Full online documentation](https://www.xach.com/lisp/quickproject).
 
 Quickproject is licensed under the MIT license; see LICENSE.txt for
 details.


### PR DESCRIPTION
This makes it possible for quickdocs.org to parse the documentation URL.

http://quickdocs.org/quickproject/

Resolves #24