### PR TITLE
remove extraneous space character from asd file template

### DIFF
--- a/default-template/system.asd
+++ b/default-template/system.asd
@@ -5,7 +5,7 @@
 (asdf:defsystem #:(#| TMPL_VAR name |#)
   :description "Describe (#| TMPL_VAR name |#) here"
   :author "(#| TMPL_VAR author |#)"
-  :license  "(#| TMPL_VAR license |#)"
+  :license "(#| TMPL_VAR license |#)"
   :version "0.0.1"
   :serial t(#| TMPL_IF depends-on |#)
   :depends-on (#| TMPL_VAR dependencies-string |#)(#| /TMPL_IF |#)


### PR DESCRIPTION
Sorry for the noise, but this has been bothering me and I can't unsee it.